### PR TITLE
Sprint 20) Перевод поиска по iTunes, истории поиска и debounce на корутины

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -58,6 +58,7 @@ dependencies {
     implementation(libs.androidx.fragment.ktx)
     implementation(libs.androidx.navigation.fragment.ktx)
     implementation(libs.androidx.navigation.ui.ktx)
+    implementation(libs.lifecycle.viewmodel.ktx)
     testImplementation(libs.junit)
     androidTestImplementation(libs.androidx.junit)
     androidTestImplementation(libs.androidx.espresso.core)

--- a/app/src/main/java/com/example/playlistmaker/data/api/search/Itunes.kt
+++ b/app/src/main/java/com/example/playlistmaker/data/api/search/Itunes.kt
@@ -8,10 +8,10 @@ import retrofit2.http.Query
 interface Itunes {
 
     @GET("search")
-    fun search(
+    suspend fun search(
         @Query("term") text: String,
         @Query("media") media:String = "music",
         @Query("entity") entity:String = "song",//song or musicTrack
         @Query("country") country:String = "RU"//US || GB || DE || RU
-    ): Call<ItunesTrackList>
+    ): ItunesTrackList
 }

--- a/app/src/main/java/com/example/playlistmaker/data/impl/player/MediaPlayerService.kt
+++ b/app/src/main/java/com/example/playlistmaker/data/impl/player/MediaPlayerService.kt
@@ -5,6 +5,11 @@ import android.media.MediaPlayer
 import android.os.Handler
 import android.os.Looper
 import android.os.SystemClock
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.GlobalScope
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.launch
 
 class MediaPlayerService(private val mediaPlayer: MediaPlayer) {
 
@@ -29,8 +34,7 @@ class MediaPlayerService(private val mediaPlayer: MediaPlayer) {
     private var url: String? = null
 
     private var STATE = State.STOPPED
-    private val handler = Handler(Looper.getMainLooper())
-    private val obj = Any()
+    private var timerJob: Job? = null
 
     fun setDisplayPorts(
         forTime: ((Int) -> Unit)?,
@@ -94,7 +98,7 @@ class MediaPlayerService(private val mediaPlayer: MediaPlayer) {
         }
         if (isPrepared) {
             mediaPlayer.start()
-            setTimeout()
+            startTimer()
         }
         STATE = State.PLAYING
         return true
@@ -106,7 +110,7 @@ class MediaPlayerService(private val mediaPlayer: MediaPlayer) {
             displayPlayProgress()
         }
         STATE = State.PAUSED
-        handler.removeCallbacksAndMessages(obj)
+        stopTimer()
         onStop?.let { it() }
     }
 
@@ -119,22 +123,31 @@ class MediaPlayerService(private val mediaPlayer: MediaPlayer) {
             displayPlayProgress()
         }
         STATE = State.STOPPED
-        handler.removeCallbacksAndMessages(obj)
+        stopTimer()
         onStop?.let { it() }
     }
 
     fun destroy() {
-        handler.removeCallbacksAndMessages(obj)
+        stopTimer()
         mediaPlayer.release()
         url = null
     }
 
-    private fun setTimeout() {
-        handler.removeCallbacksAndMessages(obj)
-        handler.postAtTime({
-            displayPlayProgress()
-            setTimeout()
-        }, obj, 1000L + SystemClock.uptimeMillis())
+    private fun startTimer() {
+
+        if (timerJob == null) {
+            timerJob = GlobalScope.launch(Dispatchers.Main) {
+                while (true) {
+                    displayPlayProgress()
+                    delay(1000L)
+                }
+            }
+        }
+    }
+
+    private fun stopTimer() {
+        timerJob?.cancel()
+        timerJob = null
     }
 
 

--- a/app/src/main/java/com/example/playlistmaker/data/impl/player/MediaPlayerService.kt
+++ b/app/src/main/java/com/example/playlistmaker/data/impl/player/MediaPlayerService.kt
@@ -139,7 +139,7 @@ class MediaPlayerService(private val mediaPlayer: MediaPlayer) {
             timerJob = GlobalScope.launch(Dispatchers.Main) {
                 while (true) {
                     displayPlayProgress()
-                    delay(1000L)
+                    delay(300L)
                 }
             }
         }

--- a/app/src/main/java/com/example/playlistmaker/data/impl/search/ITunesRepositoryImpl.kt
+++ b/app/src/main/java/com/example/playlistmaker/data/impl/search/ITunesRepositoryImpl.kt
@@ -3,153 +3,58 @@ package com.example.playlistmaker.data.impl.search
 import android.content.Context
 import android.net.ConnectivityManager
 import android.net.NetworkCapabilities
-import android.os.Handler
-import android.os.Looper
-import com.example.playlistmaker.domain.consumer.Consumer
-import com.example.playlistmaker.domain.consumer.ConsumerData
-import com.example.playlistmaker.domain.models.Track
 import com.example.playlistmaker.data.api.search.Itunes
 import com.example.playlistmaker.data.dto.search.ITunesTrackToTrackMapper
+import com.example.playlistmaker.data.dto.search.ItunesTrackList
+import com.example.playlistmaker.domain.consumer.ConsumerData
+import com.example.playlistmaker.domain.models.Track
 import com.example.playlistmaker.domain.repository.search.ITunesRepository
-import java.io.IOException
-import java.util.concurrent.atomic.AtomicBoolean
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.withContext
+import kotlin.coroutines.cancellation.CancellationException
 
 class ITunesRepositoryImpl(private val context: Context, private val api: Itunes) :
-    Thread(), ITunesRepository {
+    ITunesRepository {
 
-    private val isTerminated = AtomicBoolean(false)
-    private val lock = Object()
-    private var searchText = ""
-    private val handler = Handler(Looper.getMainLooper())
-    private var consumer: Consumer<List<Track>>? = null
-
-    init {
-        this.start()
-    }
-
-    override fun search(text: String, consumer: Consumer<List<Track>>) {
+    override suspend fun search(text: String): ConsumerData<List<Track>> {
 
         if (!isConnected()) {
-            consumer.consume(ConsumerData.Error(code = -1, message = "No internet connection"))
-            return
+            return ConsumerData.Error(code = -1, message = "No internet connection")
         }
 
-        this.doSearch(text, consumer)
-    }
+        return withContext(Dispatchers.IO) {
 
-    override fun cancel() {
-        synchronized(searchText) {
-            if (searchText.isEmpty()) return
-        }
-        doSearch(text = "", null)
-    }
+            try {
 
-    override fun destroy() {
-        isTerminated.set(true)
-        this.interrupt()
-    }
+                val iTunesTracks: ItunesTrackList = api.search(text)
 
-    private fun doSearch(text: String, consumer: Consumer<List<Track>>?) {
-        synchronized(searchText) {
-            this.searchText = text
-            this.consumer = consumer
-        }
-        synchronized(lock) {
-            lock.notify();
-        }
-    }
-
-    private fun runSearch(text: String): SearchState {
-
-        if (text.isBlank()) return SearchState.SEARCH_COMPLETE
-
-        try {
-
-            val response = api.search(text).execute()
-
-            if (text != getSearchText()) {
-                return SearchState.NEW_SEARCH_NEEDED
-            }
-
-            when (response.code()) {
-                200 -> {
-                    response.body()?.let {
-                        if (it.results.isNotEmpty()) {
-                            postResultsToMainThread(
-                                ConsumerData.Data(
-                                    value = ITunesTrackToTrackMapper.map(
-                                        itunesTracks = it.results,
-                                        context = context
-                                    )
-                                )
-                            )
-                            return SearchState.SEARCH_COMPLETE
-                        }
-                    }
-
-                    postResultsToMainThread(
-                        ConsumerData.Error(
-                            code = 404, message = "No tracks found for\"$searchText\""
+                if (iTunesTracks.results.isNotEmpty()) {
+                    ConsumerData.Data(
+                        value = ITunesTrackToTrackMapper.map(
+                            itunesTracks = iTunesTracks.results,
+                            context = context
                         )
+                    )
+                } else {
+                    ConsumerData.Error(
+                        code = 404, message = "No tracks found for\"$text\""
                     )
                 }
 
-                else -> {
-                    postResultsToMainThread(
-                        ConsumerData.Error(
-                            code = response.code(),
-                            message = "The server rejected our request with an error. One search for \"$searchText\""
-                        )
-                    )
-                }
-            }
+            } catch (error: CancellationException) {
 
-        } catch (error: IOException) {
+                ConsumerData.Error(
+                    code = -2,
+                    message = "The search was terminated"
+                )
+            } catch (error: Throwable) {
 
-            if (text != getSearchText()) {
-                return SearchState.NEW_SEARCH_NEEDED
-            }
-
-            postResultsToMainThread(
                 ConsumerData.Error(
                     code = 502,
-                    message = "Some error occurred when search for \"$searchText\""
+                    message = "Some error occurred when search for \"$text\""
                 )
-            )
-        }
-
-        return SearchState.SEARCH_COMPLETE
-    }
-
-    private fun postResultsToMainThread(data: ConsumerData<List<Track>>) {
-        handler.post {
-            consumer?.consume(data)
-        }
-    }
-
-    private fun getSearchText(): String {
-        synchronized(searchText) {
-            return searchText
-        }
-    }
-
-    override fun run() {
-        super.run()
-
-        do {
-            synchronized(lock) {
-                try {
-                    lock.wait()
-                } catch (e: InterruptedException) {
-                    isTerminated.set(true)
-                }
             }
-
-            while (!isTerminated.get() && runSearch(text = getSearchText()) == SearchState.NEW_SEARCH_NEEDED) {
-                //запускаем новый поиск если есть новый поисковый запрос
-            }
-
-        } while (!isTerminated.get())
+        }
     }
 
     private fun isConnected(): Boolean {
@@ -166,9 +71,5 @@ class ITunesRepositoryImpl(private val context: Context, private val api: Itunes
             }
         }
         return false
-    }
-
-    enum class SearchState {
-        NEW_SEARCH_NEEDED, SEARCH_COMPLETE;
     }
 }

--- a/app/src/main/java/com/example/playlistmaker/data/impl/search/ITunesRepositoryImpl.kt
+++ b/app/src/main/java/com/example/playlistmaker/data/impl/search/ITunesRepositoryImpl.kt
@@ -48,18 +48,13 @@ class ITunesRepositoryImpl(private val context: Context, private val api: Itunes
                     )
                 }
 
-            }
-            catch (error: Throwable) {
-
-                if(error is CancellationException){
-                    throw error
-                }
-                else{
-                    ConsumerData.Error(
-                        code = 502,
-                        message = "Some error occurred when search for \"$text\""
-                    )
-                }
+            } catch (error: CancellationException) {
+                throw error
+            } catch (error: Exception) {
+                ConsumerData.Error(
+                    code = 502,
+                    message = "Some error occurred when search for \"$text\""
+                )
             }
         }
     }

--- a/app/src/main/java/com/example/playlistmaker/data/impl/settings/AppSettingsRepositoryImpl.kt
+++ b/app/src/main/java/com/example/playlistmaker/data/impl/settings/AppSettingsRepositoryImpl.kt
@@ -1,7 +1,6 @@
 package com.example.playlistmaker.data.impl.settings
 
 import android.content.SharedPreferences
-import android.util.Log
 import androidx.appcompat.app.AppCompatDelegate
 import com.example.playlistmaker.domain.models.AppTheme
 import com.example.playlistmaker.domain.repository.settings.AppSettingsRepository
@@ -45,9 +44,8 @@ class AppSettingsRepositoryImpl(sharedPreferences: SharedPreferences) : AppSetti
     }
 
     override suspend fun restoreTheme() {
-        Log.d("WWW", "restoreTheme()")
+
         getTheme()?.let {
-            Log.d("WWW", it.toString())
             setTheme(it)
         }
     }

--- a/app/src/main/java/com/example/playlistmaker/data/impl/settings/AppSettingsRepositoryImpl.kt
+++ b/app/src/main/java/com/example/playlistmaker/data/impl/settings/AppSettingsRepositoryImpl.kt
@@ -1,9 +1,12 @@
 package com.example.playlistmaker.data.impl.settings
 
 import android.content.SharedPreferences
+import android.util.Log
 import androidx.appcompat.app.AppCompatDelegate
 import com.example.playlistmaker.domain.models.AppTheme
 import com.example.playlistmaker.domain.repository.settings.AppSettingsRepository
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.withContext
 
 class AppSettingsRepositoryImpl(sharedPreferences: SharedPreferences) : AppSettingsRepository {
 
@@ -21,24 +24,30 @@ class AppSettingsRepositoryImpl(sharedPreferences: SharedPreferences) : AppSetti
         )
     }
 
-    override fun saveTheme(theme: AppTheme) {
-        sharedPrefs.edit().putBoolean(DARK_THEME_KEY, theme.dark).apply()
-    }
-
-    override fun getTheme(): AppTheme? {
-
-        if (sharedPrefs.contains(DARK_THEME_KEY)) {
-            return AppTheme(
-                dark = sharedPrefs.getBoolean(DARK_THEME_KEY, false)
-            )
+    override suspend fun saveTheme(theme: AppTheme) {
+        withContext(Dispatchers.IO) {
+            sharedPrefs.edit().putBoolean(DARK_THEME_KEY, theme.dark).commit()
         }
-
-        return null
     }
 
-    override fun restoreTheme() {
+    override suspend fun getTheme(): AppTheme? {
 
+        return withContext(Dispatchers.IO) {
+
+            if (sharedPrefs.contains(DARK_THEME_KEY)) {
+                AppTheme(
+                    dark = sharedPrefs.getBoolean(DARK_THEME_KEY, false)
+                )
+            } else {
+                null
+            }
+        }
+    }
+
+    override suspend fun restoreTheme() {
+        Log.d("WWW", "restoreTheme()")
         getTheme()?.let {
+            Log.d("WWW", it.toString())
             setTheme(it)
         }
     }

--- a/app/src/main/java/com/example/playlistmaker/di/ViewModelModule.kt
+++ b/app/src/main/java/com/example/playlistmaker/di/ViewModelModule.kt
@@ -3,14 +3,13 @@ package com.example.playlistmaker.di
 import com.example.playlistmaker.viewModels.player.PlayerScreenViewModel
 import com.example.playlistmaker.viewModels.search.SearchViewModel
 import com.example.playlistmaker.viewModels.settings.SettingsViewModel
-import org.koin.android.ext.koin.androidContext
 import org.koin.androidx.viewmodel.dsl.viewModel
 import org.koin.dsl.module
 
 val viewModelModule = module {
 
     viewModel {
-        SearchViewModel(context = get(), history = get(), iTunes = get())
+        SearchViewModel(history = get(), iTunes = get())
     }
 
     viewModel { (jsonTrack: String) ->

--- a/app/src/main/java/com/example/playlistmaker/domain/consumer/Consumer.kt
+++ b/app/src/main/java/com/example/playlistmaker/domain/consumer/Consumer.kt
@@ -1,5 +1,0 @@
-package com.example.playlistmaker.domain.consumer
-
-interface Consumer<T> {
-    fun consume(data: ConsumerData<T>)
-}

--- a/app/src/main/java/com/example/playlistmaker/domain/consumer/ConsumerData.kt
+++ b/app/src/main/java/com/example/playlistmaker/domain/consumer/ConsumerData.kt
@@ -2,6 +2,5 @@ package com.example.playlistmaker.domain.consumer
 
 sealed interface ConsumerData<T> {
     data class Data<T>(val value: T) : ConsumerData<T>
-    data class Error<T>(val code:Int, val message: String) : ConsumerData<T>
-    data class CanceledRequest<T>(val code:Int) : ConsumerData<T>
+    data class Error<T>(val code: Int, val message: String) : ConsumerData<T>
 }

--- a/app/src/main/java/com/example/playlistmaker/domain/consumer/ConsumerData.kt
+++ b/app/src/main/java/com/example/playlistmaker/domain/consumer/ConsumerData.kt
@@ -3,4 +3,5 @@ package com.example.playlistmaker.domain.consumer
 sealed interface ConsumerData<T> {
     data class Data<T>(val value: T) : ConsumerData<T>
     data class Error<T>(val code:Int, val message: String) : ConsumerData<T>
+    data class CanceledRequest<T>(val code:Int) : ConsumerData<T>
 }

--- a/app/src/main/java/com/example/playlistmaker/domain/impl/TracksHistoryInteractorImpl.kt
+++ b/app/src/main/java/com/example/playlistmaker/domain/impl/TracksHistoryInteractorImpl.kt
@@ -7,16 +7,16 @@ import com.example.playlistmaker.domain.repository.TracksHistoryRepository
 class TracksHistoryInteractorImpl(private val repository: TracksHistoryRepository) :
     TracksHistoryInteractor {
 
-    override fun save(track: Track) {
+    override suspend fun save(track: Track) {
         repository.save(track)
     }
 
-    override fun getList(): List<Track> {
+    override suspend fun getList(): List<Track> {
         val list: List<Track> = repository.getList() ?: emptyList()
         return list
     }
 
-    override fun clear() {
+    override suspend fun clear() {
         repository.clear()
     }
 

--- a/app/src/main/java/com/example/playlistmaker/domain/impl/search/ITunesInteractorImpl.kt
+++ b/app/src/main/java/com/example/playlistmaker/domain/impl/search/ITunesInteractorImpl.kt
@@ -5,11 +5,12 @@ import com.example.playlistmaker.domain.models.Track
 import com.example.playlistmaker.domain.repository.search.ITunesInteractor
 import com.example.playlistmaker.domain.repository.search.ITunesRepository
 import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.flow
 
 class ITunesInteractorImpl(private val repository: ITunesRepository) : ITunesInteractor {
 
-    override suspend fun search(text: String): Flow<ConsumerData<List<Track>>> {
+    override suspend fun search(text: String): Flow<ConsumerData<List<Track>>> = flow {
 
-        return repository.search(text)
+        repository.search(text).collect { data -> emit(data) }
     }
 }

--- a/app/src/main/java/com/example/playlistmaker/domain/impl/search/ITunesInteractorImpl.kt
+++ b/app/src/main/java/com/example/playlistmaker/domain/impl/search/ITunesInteractorImpl.kt
@@ -5,12 +5,11 @@ import com.example.playlistmaker.domain.models.Track
 import com.example.playlistmaker.domain.repository.search.ITunesInteractor
 import com.example.playlistmaker.domain.repository.search.ITunesRepository
 import kotlinx.coroutines.flow.Flow
-import kotlinx.coroutines.flow.flow
 
 class ITunesInteractorImpl(private val repository: ITunesRepository) : ITunesInteractor {
 
-    override suspend fun search(text: String): Flow<ConsumerData<List<Track>>> = flow {
+    override suspend fun search(text: String): Flow<ConsumerData<List<Track>>> {
 
-        emit(repository.search(text))
+        return repository.search(text)
     }
 }

--- a/app/src/main/java/com/example/playlistmaker/domain/impl/search/ITunesInteractorImpl.kt
+++ b/app/src/main/java/com/example/playlistmaker/domain/impl/search/ITunesInteractorImpl.kt
@@ -1,23 +1,16 @@
 package com.example.playlistmaker.domain.impl.search
 
-import com.example.playlistmaker.domain.consumer.Consumer
+import com.example.playlistmaker.domain.consumer.ConsumerData
 import com.example.playlistmaker.domain.models.Track
 import com.example.playlistmaker.domain.repository.search.ITunesInteractor
 import com.example.playlistmaker.domain.repository.search.ITunesRepository
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.flow
 
 class ITunesInteractorImpl(private val repository: ITunesRepository) : ITunesInteractor {
 
-    override fun search(text: String, consumer: Consumer<List<Track>>) {
-        repository.search(text, consumer)
+    override suspend fun search(text: String): Flow<ConsumerData<List<Track>>> = flow {
+
+        emit(repository.search(text))
     }
-
-    override fun cancelSearch() {
-        repository.cancel()
-    }
-
-    override fun destroy() {
-        repository.destroy()
-    }
-
-
 }

--- a/app/src/main/java/com/example/playlistmaker/domain/impl/settings/AppSettingsInteractorImpl.kt
+++ b/app/src/main/java/com/example/playlistmaker/domain/impl/settings/AppSettingsInteractorImpl.kt
@@ -11,15 +11,15 @@ class AppSettingsInteractorImpl(private val repository: AppSettingsRepository) :
         repository.setTheme(theme)
     }
 
-    override fun saveTheme(theme: AppTheme) {
+    override suspend fun saveTheme(theme: AppTheme) {
         repository.saveTheme(theme)
     }
 
-    override fun getTheme(): AppTheme? {
+    override suspend fun getTheme(): AppTheme? {
         return repository.getTheme()
     }
 
-    override fun restoreTheme() {
+    override suspend fun restoreTheme() {
         repository.restoreTheme()
     }
 }

--- a/app/src/main/java/com/example/playlistmaker/domain/repository/TracksHistoryInteractor.kt
+++ b/app/src/main/java/com/example/playlistmaker/domain/repository/TracksHistoryInteractor.kt
@@ -4,11 +4,11 @@ import com.example.playlistmaker.domain.models.Track
 
 interface TracksHistoryInteractor {
 
-    fun save(track: Track)
+    suspend fun save(track: Track)
 
-    fun getList(): List<Track>
+    suspend fun getList(): List<Track>
 
-    fun clear()
+    suspend fun clear()
 
     fun jsonToTrack(json: String): Track?
 

--- a/app/src/main/java/com/example/playlistmaker/domain/repository/TracksHistoryRepository.kt
+++ b/app/src/main/java/com/example/playlistmaker/domain/repository/TracksHistoryRepository.kt
@@ -4,11 +4,11 @@ import com.example.playlistmaker.domain.models.Track
 
 interface TracksHistoryRepository {
 
-    fun save(track: Track)
+    suspend fun save(track: Track)
 
-    fun getList():List<Track>?
+    suspend fun getList():List<Track>?
 
-    fun clear()
+    suspend fun clear()
 
     fun jsonToTrack(json: String): Track?
 

--- a/app/src/main/java/com/example/playlistmaker/domain/repository/search/ITunesInteractor.kt
+++ b/app/src/main/java/com/example/playlistmaker/domain/repository/search/ITunesInteractor.kt
@@ -1,12 +1,9 @@
 package com.example.playlistmaker.domain.repository.search
 
-import com.example.playlistmaker.domain.consumer.Consumer
+import com.example.playlistmaker.domain.consumer.ConsumerData
 import com.example.playlistmaker.domain.models.Track
+import kotlinx.coroutines.flow.Flow
 
 interface ITunesInteractor {
-    fun search(text: String, consumer: Consumer<List<Track>>)
-
-    fun cancelSearch()
-
-    fun destroy()
+    suspend fun search(text: String): Flow<ConsumerData<List<Track>>>
 }

--- a/app/src/main/java/com/example/playlistmaker/domain/repository/search/ITunesRepository.kt
+++ b/app/src/main/java/com/example/playlistmaker/domain/repository/search/ITunesRepository.kt
@@ -1,13 +1,9 @@
 package com.example.playlistmaker.domain.repository.search
 
-import com.example.playlistmaker.domain.consumer.Consumer
+import com.example.playlistmaker.domain.consumer.ConsumerData
 import com.example.playlistmaker.domain.models.Track
 
 interface ITunesRepository {
 
-    fun search(text: String, consumer: Consumer<List<Track>>)
-
-    fun cancel()
-
-    fun destroy()
+    suspend fun search(text: String): ConsumerData<List<Track>>
 }

--- a/app/src/main/java/com/example/playlistmaker/domain/repository/search/ITunesRepository.kt
+++ b/app/src/main/java/com/example/playlistmaker/domain/repository/search/ITunesRepository.kt
@@ -2,8 +2,9 @@ package com.example.playlistmaker.domain.repository.search
 
 import com.example.playlistmaker.domain.consumer.ConsumerData
 import com.example.playlistmaker.domain.models.Track
+import kotlinx.coroutines.flow.Flow
 
 interface ITunesRepository {
 
-    suspend fun search(text: String): ConsumerData<List<Track>>
+    suspend fun search(text: String): Flow<ConsumerData<List<Track>>>
 }

--- a/app/src/main/java/com/example/playlistmaker/domain/repository/settings/AppSettingsInteractor.kt
+++ b/app/src/main/java/com/example/playlistmaker/domain/repository/settings/AppSettingsInteractor.kt
@@ -6,9 +6,9 @@ interface AppSettingsInteractor {
 
     fun setTheme(theme: AppTheme)
 
-    fun saveTheme(theme: AppTheme)
+    suspend fun saveTheme(theme: AppTheme)
 
-    fun getTheme(): AppTheme?
+    suspend fun getTheme(): AppTheme?
 
-    fun restoreTheme()
+    suspend fun restoreTheme()
 }

--- a/app/src/main/java/com/example/playlistmaker/domain/repository/settings/AppSettingsRepository.kt
+++ b/app/src/main/java/com/example/playlistmaker/domain/repository/settings/AppSettingsRepository.kt
@@ -6,9 +6,9 @@ interface AppSettingsRepository {
 
     fun setTheme(theme: AppTheme)
 
-    fun saveTheme(theme: AppTheme)
+    suspend fun saveTheme(theme: AppTheme)
 
-    fun getTheme(): AppTheme?
+    suspend fun getTheme(): AppTheme?
 
-    fun restoreTheme()
+    suspend fun restoreTheme()
 }

--- a/app/src/main/java/com/example/playlistmaker/ui/common/App.kt
+++ b/app/src/main/java/com/example/playlistmaker/ui/common/App.kt
@@ -7,6 +7,10 @@ import com.example.playlistmaker.di.interactorModule
 import com.example.playlistmaker.di.repositoryModule
 import com.example.playlistmaker.di.uiModule
 import com.example.playlistmaker.di.viewModelModule
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.GlobalScope
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.runBlocking
 import org.koin.android.ext.android.inject
 import org.koin.android.ext.koin.androidContext
 import org.koin.core.context.GlobalContext.startKoin
@@ -28,6 +32,8 @@ class App : Application() {
 
         val settings: AppSettingsInteractor by inject()
 
-        settings.restoreTheme()
+        runBlocking {
+            settings.restoreTheme()
+        }
     }
 }

--- a/app/src/main/java/com/example/playlistmaker/viewModels/search/SearchViewModel.kt
+++ b/app/src/main/java/com/example/playlistmaker/viewModels/search/SearchViewModel.kt
@@ -41,7 +41,7 @@ class SearchViewModel(
 
         searchDelayJob?.cancel()
 
-        searchDelayJob = viewModelScope.launch {
+        searchDelayJob = viewModelScope.launch(Dispatchers.Main) {
             delay(2000L)
             searchOnITunes()
         }
@@ -69,7 +69,9 @@ class SearchViewModel(
 
         if (textInFocus && searchText.isEmpty()) {
 
-            showHistory()
+            viewModelScope.launch(Dispatchers.Main) {
+                showHistory()
+            }
 
         } else if (STATE == TrackListState.HISTORY_VISIBLE) {
 
@@ -97,7 +99,7 @@ class SearchViewModel(
         }
     }
 
-    private fun showHistory() {
+    private suspend fun showHistory() {
 
         if (tracksInHistory == null) {
             tracksInHistory = history.getList()
@@ -121,7 +123,9 @@ class SearchViewModel(
 
         if (!isClickAllowed()) return Unit;
 
-        history.save(track)
+        viewModelScope.launch(Dispatchers.Main) {
+            history.save(track)
+        }
 
         liveData.setSingleEventValue(SearchData.OpenPlayerScreen(history.toJson(track)))
 
@@ -143,7 +147,7 @@ class SearchViewModel(
     private fun isClickAllowed(): Boolean {
         if (trackClickAllowed) {
             trackClickAllowed = false
-            viewModelScope.launch {
+            viewModelScope.launch(Dispatchers.Main) {
                 delay(1000L)
                 trackClickAllowed = true
             }
@@ -154,7 +158,9 @@ class SearchViewModel(
 
     fun clearHistory() {
         tracksInHistory = null
-        history.clear()
+        viewModelScope.launch(Dispatchers.Main) {
+            history.clear()
+        }
         changeState(TrackListState.HISTORY_EMPTY)
     }
 

--- a/app/src/main/java/com/example/playlistmaker/viewModels/search/SearchViewModel.kt
+++ b/app/src/main/java/com/example/playlistmaker/viewModels/search/SearchViewModel.kt
@@ -1,31 +1,26 @@
 package com.example.playlistmaker.viewModels.search
 
-import android.content.Context
-import android.content.Intent
-import android.os.Handler
-import android.os.Looper
-import android.os.SystemClock
-import android.util.Log
 import androidx.lifecycle.LiveData
 import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
 import com.example.playlistmaker.domain.consumer.Consumer
 import com.example.playlistmaker.domain.consumer.ConsumerData
 import com.example.playlistmaker.domain.models.Track
 import com.example.playlistmaker.domain.repository.TracksHistoryInteractor
-import com.example.playlistmaker.viewModels.common.LiveDataWithStartDataSet
 import com.example.playlistmaker.domain.repository.search.ITunesInteractor
-import com.example.playlistmaker.ui.search.SearchFragmentDirections
+import com.example.playlistmaker.viewModels.common.LiveDataWithStartDataSet
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.launch
 
 class SearchViewModel(
-    private val context: Context,
     private val history: TracksHistoryInteractor,
     private val iTunes: ITunesInteractor
 ) : ViewModel() {
 
     private val liveData = LiveDataWithStartDataSet<SearchData>()
 
-    private val handler = Handler(Looper.getMainLooper())
-    private val obj = Any()
+    private var searchDelayJob: Job? = null
 
     private var searchText: String = ""
     private var textInFocus: Boolean = false
@@ -42,11 +37,12 @@ class SearchViewModel(
 
         searchText = text
 
-        handler.removeCallbacksAndMessages(obj)
+        searchDelayJob?.cancel()
 
-        handler.postAtTime({
+        searchDelayJob = viewModelScope.launch {
+            delay(2000L)
             searchOnITunes()
-        }, obj, 2000L + SystemClock.uptimeMillis())
+        }
 
         switchHistoryVisibility()
 
@@ -55,7 +51,7 @@ class SearchViewModel(
 
     fun onActionButton() {
         searchOnITunes()
-        handler.removeCallbacksAndMessages(obj)
+        searchDelayJob?.cancel()
     }
 
     fun onFocusChanged(hasFocus: Boolean) {
@@ -128,7 +124,8 @@ class SearchViewModel(
         liveData.setSingleEventValue(SearchData.OpenPlayerScreen(history.toJson(track)))
 
         tracksInHistory?.let { list ->
-            tracksInHistory = list.partition { it.trackId == track.trackId }.let { it.first + it.second }
+            tracksInHistory =
+                list.partition { it.trackId == track.trackId }.let { it.first + it.second }
         }
 
         if (STATE == TrackListState.HISTORY_VISIBLE) {
@@ -144,9 +141,10 @@ class SearchViewModel(
     private fun isClickAllowed(): Boolean {
         if (trackClickAllowed) {
             trackClickAllowed = false
-            handler.postDelayed({
+            viewModelScope.launch {
+                delay(1000L)
                 trackClickAllowed = true
-            }, 1000L)
+            }
             return true
         }
         return false

--- a/app/src/main/java/com/example/playlistmaker/viewModels/settings/SettingsViewModel.kt
+++ b/app/src/main/java/com/example/playlistmaker/viewModels/settings/SettingsViewModel.kt
@@ -1,11 +1,14 @@
 package com.example.playlistmaker.viewModels.settings
 
 import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
 import com.example.playlistmaker.domain.models.AppTheme
 import com.example.playlistmaker.domain.models.EmailData
 import com.example.playlistmaker.domain.models.ShareData
-import com.example.playlistmaker.domain.repository.settings.AppSettingsInteractor
 import com.example.playlistmaker.domain.repository.ExternalNavigatorInteractor
+import com.example.playlistmaker.domain.repository.settings.AppSettingsInteractor
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.launch
 
 class SettingsViewModel(
     private val navigator: ExternalNavigatorInteractor,
@@ -26,6 +29,8 @@ class SettingsViewModel(
 
     fun switchTheme(isDarkTheme: Boolean) {
         settings.setTheme(AppTheme(isDarkTheme))
-        settings.saveTheme(AppTheme(isDarkTheme))
+        viewModelScope.launch(Dispatchers.Main) {
+            settings.saveTheme(AppTheme(isDarkTheme))
+        }
     }
 }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -21,6 +21,7 @@ fragmentKtx = "1.8.2"
 navigationFragmentKtx = "2.7.7"
 navigationUiKtx = "2.7.7"
 androidxNavigationSafeargsGradlePlugin = "2.7.7"
+lifecycleViewmodelKtxVersion = "2.8.5"
 
 [libraries]
 androidx-core-ktx = { group = "androidx.core", name = "core-ktx", version.ref = "coreKtx" }
@@ -42,6 +43,7 @@ androidx-lifecycle-viewmodel-ktx = { group = "androidx.lifecycle", name = "lifec
 androidx-fragment-ktx = { group = "androidx.fragment", name = "fragment-ktx", version.ref = "fragmentKtx" }
 androidx-navigation-fragment-ktx = { group = "androidx.navigation", name = "navigation-fragment-ktx", version.ref = "navigationFragmentKtx" }
 androidx-navigation-ui-ktx = { group = "androidx.navigation", name = "navigation-ui-ktx", version.ref = "navigationUiKtx" }
+lifecycle-viewmodel-ktx = { group = "androidx.lifecycle", name = "lifecycle-viewmodel-ktx", version.ref = "lifecycleViewmodelKtxVersion" }
 
 
 [plugins]


### PR DESCRIPTION
Что предстоит сделать:

1. Переделайте реализацию debounce для отправки поискового запроса и нажатия на элементы списка. Вместо прежнего подхода с использованием Handler используйте корутины. Это позволит сделать процесс более эффективным и управляемым.
2. Обновите реализацию отображения прогресса воспроизведения на экране «Аудиоплеер». Теперь в этой реализации нужно использовать корутины. Это обеспечит более простое и надёжное отображение прогресса.
3. Наконец, выполнение самого сетевого запроса для поиска треков теперь должно быть реализовано с использованием корутин и Flow на всех уровнях архитектуры исходного кода. Это позволит вам дополнительно попрактиковаться в использовании этих инструментов в полном масштабе и на конкретной задаче. Вы получите возможность глубже понять, как они обеспечивают выполнение асинхронных операций и помогают работать с потоками данных.